### PR TITLE
XSetInputFocus function added.

### DIFF
--- a/annotated.c
+++ b/annotated.c
@@ -105,7 +105,13 @@ int main(void)
          * window that was grabbed on -- in this case, the root window.
          */
         if(ev.type == KeyPress && ev.xkey.subwindow != None)
+        {
             XRaiseWindow(dpy, ev.xkey.subwindow);
+            /* this is change input focus (for example: keyboard) to target window.
+             * if window closed revert focus to parent window.
+             */
+            XSetInputFocus(dpy, ev.xkey.subwindow, RevertToParent, CurrentTime);
+        }
         else if(ev.type == ButtonPress && ev.xbutton.subwindow != None)
         {
             /* we "remember" the position of the pointer at the beginning of

--- a/tinywm.c
+++ b/tinywm.c
@@ -28,7 +28,10 @@ int main(void)
     {
         XNextEvent(dpy, &ev);
         if(ev.type == KeyPress && ev.xkey.subwindow != None)
+        {
             XRaiseWindow(dpy, ev.xkey.subwindow);
+            XSetInputFocus(dpy, ev.xkey.subwindow, RevertToParent, CurrentTime);
+        }
         else if(ev.type == ButtonPress && ev.xbutton.subwindow != None)
         {
             XGetWindowAttributes(dpy, ev.xbutton.subwindow, &attr);


### PR DESCRIPTION
Some of windows steal input focus and never release so we need add `XSetInputFocus` function for window focus controlling.

